### PR TITLE
Fix broken link in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ To launch a local instance of the forum, run those commands (linux):
 - `mkdir data`
 - `go run run.go --authkey 0 --dev`
 
-It should respond `Serving forum on :8277`. Just go on [http://localhost:8272](http://localhost:8272).
+It should respond `Serving forum on :8277`. Just go on [http://localhost:8277](http://localhost:8277).


### PR DESCRIPTION
Previously, the link in the README.md pointed to http://localhost:8272, which is the correct URL for a non-development environment. However, since the README.md describes a launch with the `--dev` flag, the link should point to http://localhost:8277.